### PR TITLE
feat: expose decorated component via `innerRef` prop

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -52,7 +52,16 @@ export default function autofill(DecoratedComponent) {
         }
 
         render() {
-            return <DecoratedComponent {...this.props}/>;
+          const { innerRef } = this.props;
+          const propsForElement = {
+            ...this.props
+          };
+
+          if (innerRef) {
+            propsForElement.ref = innerRef;
+          }
+
+          return React.createElement(DecoratedComponent, propsForElement);
         }
 
     }


### PR DESCRIPTION
This allows you to get a reference to the decorated component instead of the HOC itself.